### PR TITLE
Fixes conpath bug

### DIFF
--- a/src/org/zalando/stups/friboo/ring.clj
+++ b/src/org/zalando/stups/friboo/ring.clj
@@ -29,15 +29,27 @@
     (not-found {})
     (response (first results))))
 
+(defmacro xor
+  [a b]
+  `(or (and ~a (not ~b))
+       (and (not ~a) ~b)))
+
 (defn conpath
   "Concatenates path elements to an URL."
   [url & path]
   (let [[x & xs] path]
     (if x
-      (let [url (if (or
-                      (.endsWith url "/")
-                      (.startsWith x "/"))
+      (let [first-with-slash (.endsWith url "/")
+            last-with-slash  (.startsWith x "/")
+            url (if (xor first-with-slash
+                         last-with-slash)
+                  ; concat if exactly one of them has a /
                   (str url x)
-                  (str url "/" x))]
+                  (if (and first-with-slash
+                           last-with-slash)
+                    ; if both have a /, remove one
+                    (str url (s/replace-first x #"/" ""))
+                    ; if none have a /, add one
+                    (str url "/" x)))]
         (recur url xs))
       url)))

--- a/src/org/zalando/stups/friboo/ring.clj
+++ b/src/org/zalando/stups/friboo/ring.clj
@@ -39,8 +39,8 @@
   "Concatenates path elements to an URL."
   [url & path]
   (let [[x & xs] path]
-    (if x
-      (let [first-with-slash (.endsWith url "/")
+    (let [x (str x)
+          first-with-slash (.endsWith url "/")
             last-with-slash  (.startsWith x "/")
             url (if (xor first-with-slash
                          last-with-slash)
@@ -52,5 +52,6 @@
                     (str url (s/replace-first x #"/" ""))
                     ; if none have a /, add one
                     (str url "/" x)))]
-        (recur url xs))
-      url)))
+      (if xs
+        (recur url xs)
+        url))))

--- a/src/org/zalando/stups/friboo/ring.clj
+++ b/src/org/zalando/stups/friboo/ring.clj
@@ -13,7 +13,8 @@
 ; limitations under the License.
 
 (ns org.zalando.stups.friboo.ring
-  (:require [ring.util.response :refer :all]))
+  (:require [ring.util.response :refer :all]
+            [clojure.string :as s]))
 
 ;; some convinience helpers
 

--- a/test/org/zalando/stups/friboo/ring_test.clj
+++ b/test/org/zalando/stups/friboo/ring_test.clj
@@ -1,0 +1,16 @@
+(ns org.zalando.stups.friboo.ring-test
+  (:require [clojure.test :refer :all]
+            [org.zalando.stups.friboo.ring :refer :all]))
+
+(deftest test-conpath
+  (are [conpath-args expected-path]
+    (= (apply conpath conpath-args) expected-path)
+
+    ["https://example.com/" "test"] "https://example.com/test"
+    ["https://example.com/" "/test"] "https://example.com/test"
+    ["https://example.com" "/test"] "https://example.com/test"
+    ["https://example.com" "test"] "https://example.com/test"
+    ["https://example.com/" "test" "123"] "https://example.com/test/123"
+    ["https://example.com/" 123 "test/foo" "bar"] "https://example.com/123/test/foo/bar"
+    ["https://example.com/" 123 "/test"] "https://example.com/123/test"
+    ["https://example.com/" nil "/test"] "https://example.com/test"))


### PR DESCRIPTION
`(conpath "url" "/endswithslash/" "/startswithslash")` would produce `"url/endswithslash//startswithslash"` (notice the double slash in between).
