### PR TITLE
Exclude "open_id" key from :tokeninfo from audit logs

### DIFF
--- a/test/org/zalando/stups/friboo/system/audit_log_test.clj
+++ b/test/org/zalando/stups/friboo/system/audit_log_test.clj
@@ -53,6 +53,7 @@
                        :configuration  "will be erased"
                        :body           "will be erased"
                        :tokeninfo      {"access_token" "will be erased"
+                                        "open_id"      "will be erased"
                                         "uid"          "testuser"}
                        :headers        {"authorization" "will be erased"
                                         "content-type"  "application/json"}


### PR DESCRIPTION
Closes #54 
