### PR TITLE
Customize resolver fns

### DIFF
--- a/src/org/zalando/stups/friboo/system/http.clj
+++ b/src/org/zalando/stups/friboo/system/http.clj
@@ -44,7 +44,7 @@
   "According to the swagger spec, parameter names are only unique with their type. This one assumes that parameter names
    are unique in general and flattens them for easier access."
   [request]
-  (apply merge (map (fn [[k v]] v) (:parameters request))))
+  (apply merge (vals (:parameters request))))
 
 (defn compute-request-info
   "Creates a nice, readable request info text for logline prefixing."
@@ -179,7 +179,7 @@
                                            (do
                                              (log/info "Checking access tokens against %s." (:tokeninfo-url configuration))
                                              (oauth2/oauth-2.0 configuration oauth2/check-corresponding-attributes
-                                                        :resolver-fn oauth2/resolve-access-token))
+                                                               :resolver-fn oauth2/resolve-access-token))
                                            (do
                                              (log/warn "No token info URL configured; NOT ENFORCING SECURITY!")
                                              (oauth2/allow-all)))})

--- a/test/org/zalando/stups/friboo/system/http_test.clj
+++ b/test/org/zalando/stups/friboo/system/http_test.clj
@@ -2,6 +2,9 @@
   (:require [clojure.test :refer :all]
             [org.zalando.stups.friboo.system.http :refer :all]))
 
+(deftest test-flatten-parameters
+  (is (= {:foo 1 :bar 2} (flatten-parameters {:parameters {:query {:foo 1} :path {:bar 2}}}))))
+
 (deftest test-map-authorization-header-simple
   (is (= "xyz" (map-authorization-header "xyz")))
   (is (= "Bearer 123" (map-authorization-header "Token 123"))))

--- a/test/org/zalando/stups/friboo/system/http_test.clj
+++ b/test/org/zalando/stups/friboo/system/http_test.clj
@@ -12,29 +12,40 @@
 (deftest test-map-authorization-header-basic-auth
   (is (= "Bearer 123" (map-authorization-header "Basic b2F1dGgyOjEyMw=="))))
 
-(defn foo-handler-with-args [params request dependency-1]
+(defn foo-operation-with-args [params request dependency-1]
   [params request dependency-1])
 
-(defn foo-handler-with-map [params request dependency-map]
+(defn foo-operation-with-map [params request dependency-map]
   [params request dependency-map])
 
 (deftest test-make-resolver-fn-with-deps
   (let [request {:parameters {:path {:pp-1 1}}}]
-    (are [?result ?handler-name ?resolver-factory]
+    (are [?result ?operation-fn-name ?resolver-factory]
       (= ?result (let [resolver-fn (?resolver-factory ['dep-1] ["dep-1-value"])
-                       handler-fn (resolver-fn {"operationId" ?handler-name})]
-                   (handler-fn request)))
-      [{:pp-1 1} request "dep-1-value"] (str `foo-handler-with-args) make-resolver-fn-with-deps-as-args
-      [{:pp-1 1} request {:dep-1 "dep-1-value"}] (str `foo-handler-with-map) make-resolver-fn-with-deps-as-map)))
+                       operation-fn (resolver-fn {"operationId" ?operation-fn-name})]
+                   (operation-fn request)))
+      [{:pp-1 1} request "dep-1-value"] (str `foo-operation-with-args) make-resolver-fn-with-deps-as-args
+      [{:pp-1 1} request {:dep-1 "dep-1-value"}] (str `foo-operation-with-map) make-resolver-fn-with-deps-as-map)))
 
-(def-http-component HttpTest "foo.yaml" [db])
+(deftest test-select-resolver-fn-maker
+  (is (= make-resolver-fn-with-deps-as-args
+         (select-resolver-fn-maker {})))
+  (is (= "custom-maker"
+         (select-resolver-fn-maker {:resolver-fn-maker "custom-maker"})))
+  (is (= make-resolver-fn-with-deps-as-map
+         (select-resolver-fn-maker {:dependencies-as-map true :resolver-fn-maker "custom-maker"}))))
+
+(def-http-component HttpTest "foo.yaml" [db] :dependencies-as-map true)
 
 (deftest test-def-http-component
   (let [http (map->HttpTest {:configuration "configuration" :db "db" :metrics "metrics" :audit-log "audit-log"})]
-    (with-redefs [make-resolver-fn-with-deps-as-args (fn [dep-names dep-values]
-                                                       (is (= ['db] dep-names))
-                                                       (is (= ["db"] dep-values))
-                                                       "resolver-fn")
+    (with-redefs [select-resolver-fn-maker (fn [opts]
+                                             (is (= opts {:dependencies-as-map true}))
+                                             make-resolver-fn-with-deps-as-map)
+                  make-resolver-fn-with-deps-as-map (fn [dep-names dep-values]
+                                                      (is (= ['db] dep-names))
+                                                      (is (= ["db"] dep-values))
+                                                      "resolver-fn")
                   start-component (fn [this metrics audit-log definition resolver-fn]
                                     (is (= [metrics audit-log definition resolver-fn]
                                            ["metrics" "audit-log" "foo.yaml" "resolver-fn"]))

--- a/test/org/zalando/stups/friboo/system/http_test.clj
+++ b/test/org/zalando/stups/friboo/system/http_test.clj
@@ -11,3 +11,32 @@
 
 (deftest test-map-authorization-header-basic-auth
   (is (= "Bearer 123" (map-authorization-header "Basic b2F1dGgyOjEyMw=="))))
+
+(defn foo-handler-with-args [params request dependency-1]
+  [params request dependency-1])
+
+(defn foo-handler-with-map [params request dependency-map]
+  [params request dependency-map])
+
+(deftest test-make-resolver-fn-with-deps
+  (let [request {:parameters {:path {:pp-1 1}}}]
+    (are [?result ?handler-name ?resolver-factory]
+      (= ?result (let [resolver-fn (?resolver-factory ['dep-1] ["dep-1-value"])
+                       handler-fn (resolver-fn {"operationId" ?handler-name})]
+                   (handler-fn request)))
+      [{:pp-1 1} request "dep-1-value"] (str `foo-handler-with-args) make-resolver-fn-with-deps-as-args
+      [{:pp-1 1} request {:dep-1 "dep-1-value"}] (str `foo-handler-with-map) make-resolver-fn-with-deps-as-map)))
+
+(def-http-component HttpTest "foo.yaml" [db])
+
+(deftest test-def-http-component
+  (let [http (map->HttpTest {:configuration "configuration" :db "db" :metrics "metrics" :audit-log "audit-log"})]
+    (with-redefs [make-resolver-fn-with-deps-as-args (fn [dep-names dep-values]
+                                                       (is (= ['db] dep-names))
+                                                       (is (= ["db"] dep-values))
+                                                       "resolver-fn")
+                  start-component (fn [this metrics audit-log definition resolver-fn]
+                                    (is (= [metrics audit-log definition resolver-fn]
+                                           ["metrics" "audit-log" "foo.yaml" "resolver-fn"]))
+                                    this)]
+      (com.stuartsierra.component/start http))))


### PR DESCRIPTION
Enable the user to specify the way how he wants his operation functions to be called (by providing his own resolver-fn or by selecting from the predefined ones).
#48
