### PR TITLE
Explicitly require clojure.edn

### DIFF
--- a/template/resources/leiningen/new/friboo/user.clj
+++ b/template/resources/leiningen/new/friboo/user.clj
@@ -4,6 +4,7 @@
   (:require [clojure.java.javadoc :refer [javadoc]]
             [clojure.pprint :refer [pprint]]
             [clojure.reflect :refer [reflect]]
+            [clojure.edn :refer [read-string]]
             [clojure.repl :refer [apropos dir doc find-doc pst source]]
             [clojure.tools.namespace.repl :refer [refresh refresh-all]]
             [com.stuartsierra.component :as component]
@@ -20,7 +21,7 @@
     (slurp file)))
 
 (defn load-dev-config [file]
-  (clojure.edn/read-string (slurp-if-exists file)))
+  (read-string (slurp-if-exists file)))
 
 (defn start
   "Starts the system running, sets the Var #'system."

--- a/template/resources/leiningen/new/friboo/user.clj
+++ b/template/resources/leiningen/new/friboo/user.clj
@@ -4,7 +4,7 @@
   (:require [clojure.java.javadoc :refer [javadoc]]
             [clojure.pprint :refer [pprint]]
             [clojure.reflect :refer [reflect]]
-            [clojure.edn :refer [read-string]]
+            clojure.edn
             [clojure.repl :refer [apropos dir doc find-doc pst source]]
             [clojure.tools.namespace.repl :refer [refresh refresh-all]]
             [com.stuartsierra.component :as component]
@@ -21,7 +21,7 @@
     (slurp file)))
 
 (defn load-dev-config [file]
-  (read-string (slurp-if-exists file)))
+  (clojure.edn/read-string (slurp-if-exists file)))
 
 (defn start
   "Starts the system running, sets the Var #'system."


### PR DESCRIPTION
Without require clojure.edn might not be available.
Also explicit dependency looks better.

I wonder what test should be here though.
