### PR TITLE
Introduce explicit audit loggers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 
 sudo: false
 
-script: CLOVERAGE_VERSION=1.0.7 lein cloverage --coveralls
+script: CLOVERAGE_VERSION=1.0.7-SNAPSHOT lein cloverage --coveralls
 
 after_script:
   - curl -F 'json_file=@target/coverage/coveralls.json' https://coveralls.io/api/v1/jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 
 sudo: false
 
-script: CLOVERAGE_VERSION=1.0.4-SNAPSHOT lein cloverage --coveralls
+script: CLOVERAGE_VERSION=1.0.7 lein cloverage --coveralls
 
 after_script:
   - curl -F 'json_file=@target/coverage/coveralls.json' https://coveralls.io/api/v1/jobs

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Friboo encourages an "API First" approach based on the [Swagger specification](h
 
 ## Leiningen dependency
 
-    [org.zalando.stups/friboo 1.9.0]
+    [org.zalando.stups/friboo 1.10.0]
 
 ## Why Friboo?
 
@@ -166,10 +166,12 @@ Initialize the component with its configuration in the `:configuration` key:
 
 TODO link to jdbc documentation, pool specific configuration like min- and max-pool-size
 
-### Audit Log Component
+### Audit Log Component (Deprecated, see next section)
 
 The audit log component aims to collect logs of all modifying HTTP requests (POST, PUT, PATCH, DELETE) and 
 store them in an S3 bucket. You can then use this information to create an audit trail.
+
+**Will be removed in a future release!**
 
 #### Configuration Options
 
@@ -181,6 +183,12 @@ store them in an S3 bucket. You can then use this information to create an audit
     * to build a meaningful file name pattern, use the environment variables `APPLICATION_ID`, `APPLICATION_VERSION`
       and `INSTANCE_ID`
         * `INSTANCE_ID` defaults to random UUID
+
+### New Audit Logger Components
+
+Since the old audit log component does not suit our needs anymore, we introduce new audit log components
+that you have to explicitly call with clojure maps, which get serialized to JSON and shipped somewhere.
+Currently there are S3 and HTTP shippers.
 
 ### Metrics Component
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Friboo encourages an "API First" approach based on the [Swagger specification](h
 
 ## Leiningen dependency
 
-    [org.zalando.stups/friboo 1.10.0]
+    [org.zalando.stups/friboo 1.9.0]
 
 ## Why Friboo?
 

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,31 @@
+(ns user
+  "Tools for interactive development with the REPL. This file should
+  not be included in a production build of the application."
+  (:require
+    [clojure.java.javadoc :refer [javadoc]]
+    [clojure.pprint :refer [pprint]]
+    [clojure.reflect :refer [reflect]]
+    [clojure.repl :refer [apropos dir doc find-doc pst source]]
+    [clojure.tools.namespace.repl :refer [refresh refresh-all]]
+    [clojure.edn :as edn]
+    [clojure.test :refer [run-all-tests]]))
+
+(def system
+  "A Var containing an object representing the application under
+  development."
+  nil)
+
+(defn slurp-if-exists [file]
+  (when (.exists (clojure.java.io/as-file file))
+    (slurp file)))
+
+(defn load-dev-config [file]
+  (edn/read-string (slurp-if-exists file)))
+
+(defn run-tests []
+  (run-all-tests #"org.zalando.stups.friboo.*-test"))
+
+(defn tests
+  "Stops the system, reloads modified source files and runs tests"
+  []
+  (refresh :after 'user/run-tests))

--- a/profiles.clj
+++ b/profiles.clj
@@ -1,6 +1,7 @@
-{:dev {:env          {:tokeninfo-url "default-tokeninfo"}
-       :repl-options {:init-ns user}
-       :source-paths ["dev"]
-       :dependencies [[midje "1.8.3"]
-                      [org.clojure/tools.namespace "0.2.11"]
-                      [org.clojure/java.classpath "0.2.3"]]}}
+{:test {:dependencies [[midje "1.8.3"]]
+        :env          {:tokeninfo-url "default-tokeninfo"}}
+ :dev  {:repl-options {:init-ns user}
+        :source-paths ["dev"]
+        :dependencies [[midje "1.8.3"]
+                       [org.clojure/tools.namespace "0.2.11"]
+                       [org.clojure/java.classpath "0.2.3"]]}}

--- a/profiles.clj
+++ b/profiles.clj
@@ -1,1 +1,6 @@
-{:test {:env {:tokeninfo-url "default-tokeninfo"}}}
+{:dev {:env          {:tokeninfo-url "default-tokeninfo"}
+       :repl-options {:init-ns user}
+       :source-paths ["dev"]
+       :dependencies [[midje "1.8.3"]
+                      [org.clojure/tools.namespace "0.2.11"]
+                      [org.clojure/java.classpath "0.2.3"]]}}

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  [io.sarnowski/swagger1st "0.21.0"]
                  [org.zalando.stups/txdemarcator "0.7.0"]
                  [com.stuartsierra/component "0.3.1"]
+                 [digest "1.4.4"]
                  [ring "1.4.0"]
                  [org.eclipse.jetty/jetty-servlet "9.2.10.v20150310"]  ; needs to be in sync with ring dependency
                  [amalloy/ring-gzip-middleware "0.1.3"]

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                  [commons-codec "1.10"]
                  [com.newrelic.agent.java/newrelic-api "3.26.1"]]
 
-  :plugins [[lein-cloverage "1.0.7"]
+  :plugins [[lein-cloverage "1.0.7-SNAPSHOT"]
             [lein-environ "1.0.2"]]
 
   :pom-addition [:developers

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                  [com.jolbox/bonecp "0.8.0.RELEASE"]
                  [org.flywaydb/flyway-core "4.0"]
                  [org.postgresql/postgresql "9.4.1208"]
-                 [amazonica "0.3.51" :exclusions [org.apache.httpcomponents/httpclient joda-time]]
+                 [amazonica "0.3.76" :exclusions [org.apache.httpcomponents/httpclient joda-time]]
                  [org.clojure/data.codec "0.1.0"]
                  [overtone/at-at "1.2.0"]
                  [org.zalando.stups/tokens "0.9.8"]

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                  [commons-codec "1.10"]
                  [com.newrelic.agent.java/newrelic-api "3.26.1"]]
 
-  :plugins [[lein-cloverage "1.0.6"]
+  :plugins [[lein-cloverage "1.0.7"]
             [lein-environ "1.0.2"]]
 
   :pom-addition [:developers

--- a/src/org/zalando/stups/friboo/system/audit_log.clj
+++ b/src/org/zalando/stups/friboo/system/audit_log.clj
@@ -122,6 +122,7 @@
   Lifecycle
 
   (start [component]
+    (log/warn "DEPRECATED use of audit-log component. Please one of the explicit audit-loggers instead.")
     (if (running? component)
       ; then
       (do

--- a/src/org/zalando/stups/friboo/system/audit_logger/http.clj
+++ b/src/org/zalando/stups/friboo/system/audit_logger/http.clj
@@ -13,14 +13,15 @@
         token-name (or (:token-name config) :http-audit-logger)
         id         (d/digest body)
         url        (ring/conpath (:api-url config) id)]
-    (try
-      (http/put url {:body        body
-                     :oauth-token (oauth2/access-token token-name (:tokens config))
-                     :as          :json})
-      (log/info "Wrote audit event with id %s" id)
-      (catch Exception e
-        ; log to console as fallback
-        (log/error e "Could not write audit event: %s" body)))))
+    (future
+      (try
+        (http/put url {:body        body
+                       :oauth-token (oauth2/access-token token-name (:tokens config))
+                       :as          :json})
+        (log/info "Wrote audit event with id %s" id)
+        (catch Exception e
+          ; log to console as fallback
+          (log/error e "Could not write audit event: %s" body))))))
 
 (defn logger-factory
   [config tokens]

--- a/src/org/zalando/stups/friboo/system/audit_logger/http.clj
+++ b/src/org/zalando/stups/friboo/system/audit_logger/http.clj
@@ -1,0 +1,46 @@
+(ns org.zalando.stups.friboo.system.audit-logger.http
+  (:require [cheshire.core :as json]
+            [clj-http.client :as http]
+            [com.stuartsierra.component :as component]
+            [org.zalando.stups.friboo.ring :as ring]
+            [org.zalando.stups.friboo.system.digest :as d]
+            [org.zalando.stups.friboo.system.oauth2 :as oauth2]
+            [org.zalando.stups.friboo.log :as log]))
+
+(defn log
+  [config event]
+  (let [body       (json/encode event)
+        token-name (or (:token-name config) :http-audit-logger)
+        id         (d/digest body)
+        url        (ring/conpath (:api-url config) id)]
+    (try
+      (http/put url {:body        body
+                     :oauth-token (oauth2/access-token token-name (:tokens config))
+                     :as          :json})
+      (log/info "Wrote audit event with id %s" id)
+      (catch Exception e
+        ; log to console as fallback
+        (log/error e "Could not write audit event: %s" body)))))
+
+(defn logger-factory
+  [config tokens]
+  (partial log (->
+                 config
+                 (assoc :tokens tokens))))
+
+(defrecord Http
+  [configuration tokens]
+  component/Lifecycle
+  (start
+    [this]
+    (if (:log-fn this)
+      (do
+        (log/info "HTTP audit logger already running")
+        this)
+      (do
+        (log/info "Starting HTTP audit logger")
+        (assoc this :log-fn (logger-factory configuration tokens)))))
+  (stop
+    [this]
+    (log/info "Shutting down HTTP audit logger")
+    (dissoc this :log-fn)))

--- a/src/org/zalando/stups/friboo/system/audit_logger/s3.clj
+++ b/src/org/zalando/stups/friboo/system/audit_logger/s3.clj
@@ -1,0 +1,53 @@
+(ns org.zalando.stups.friboo.system.audit-logger.s3
+  (:require [amazonica.aws.s3 :as s3]
+            [com.stuartsierra.component :as component]
+            [cheshire.core :as json]
+            [clj-time.core :as time]
+            [clj-time.format :as time-format]
+            [org.zalando.stups.friboo.log :as log]
+            [org.zalando.stups.friboo.system.digest :as d]
+            [org.zalando.stups.friboo.ring :as ring])
+  (:import (java.io ByteArrayInputStream)))
+
+(defn log
+  [config event]
+  (let [body           (json/encode event)
+        id             (d/digest body)
+        bucket         (:bucket config)
+        content-length (count body)
+        key            (time-format/unparse (:formatter config) (time/now))
+        input-stream   (new ByteArrayInputStream (.getBytes body "UTF-8"))]
+    (try
+      (s3/put-object
+        :bucket-name bucket
+        :key (ring/conpath key id)
+        :metadata {:content-length content-length
+                   :content-type   "application/json"}
+        :input-stream input-stream)
+      (log/info "Wrote audit event with id %s" id)
+      (catch Exception e
+        (log/error e "Could not write audit event: %s" body)))))
+
+(defn logger-factory
+  [config]
+  (let [bucket        (:s3-bucket config)
+        format-string (or (:s3-bucket-key config) "yyyy/MM/dd/")
+        formatter     (time-format/formatter format-string time/utc)]
+    (partial log {:bucket    bucket
+                  :formatter formatter})))
+
+(defrecord S3
+  [configuration]
+  component/Lifecycle
+  (start
+    [this]
+    (if (:log-fn this)
+      (do
+        (log/info "S3 audit logger already running")
+        this)
+      (do
+        (log/info "Starting S3 audit logger")
+        (assoc this :log-fn (logger-factory configuration)))))
+  (stop
+    [this]
+    (dissoc this :log-fn)))

--- a/src/org/zalando/stups/friboo/system/audit_logger/s3.clj
+++ b/src/org/zalando/stups/friboo/system/audit_logger/s3.clj
@@ -17,16 +17,17 @@
         content-length (count body)
         key            (time-format/unparse (:formatter config) (time/now))
         input-stream   (new ByteArrayInputStream (.getBytes body "UTF-8"))]
-    (try
-      (s3/put-object
-        :bucket-name bucket
-        :key (ring/conpath key id)
-        :metadata {:content-length content-length
-                   :content-type   "application/json"}
-        :input-stream input-stream)
-      (log/info "Wrote audit event with id %s" id)
-      (catch Exception e
-        (log/error e "Could not write audit event: %s" body)))))
+    (future
+      (try
+        (s3/put-object
+          :bucket-name bucket
+          :key (ring/conpath key id)
+          :metadata {:content-length content-length
+                     :content-type   "application/json"}
+          :input-stream input-stream)
+        (log/info "Wrote audit event with id %s" id)
+        (catch Exception e
+          (log/error e "Could not write audit event: %s" body))))))
 
 (defn logger-factory
   [config]

--- a/src/org/zalando/stups/friboo/system/digest.clj
+++ b/src/org/zalando/stups/friboo/system/digest.clj
@@ -1,17 +1,8 @@
 (ns org.zalando.stups.friboo.system.digest
-  (:import (java.security MessageDigest)))
+  (:require [digest :as d]))
 
 (defn digest
   ([input]
-   (digest input "SHA-256"))
-  ([input algorithm]
    {:pre [(string? input)
-          (not (clojure.string/blank? input))
-          (#{"SHA-256" "SHA-1" "MD5"} algorithm)]}
-   (let [input-bytes (.getBytes input "UTF-8")
-         md          (doto
-                       (MessageDigest/getInstance algorithm)
-                       (.update input-bytes))
-         hash        (.digest md)
-         result      (apply str (map #(format "%02x" (bit-and % 0xff)) hash))]
-     result)))
+          (not (clojure.string/blank? input))]}
+   (d/sha-256 input)))

--- a/src/org/zalando/stups/friboo/system/digest.clj
+++ b/src/org/zalando/stups/friboo/system/digest.clj
@@ -1,0 +1,17 @@
+(ns org.zalando.stups.friboo.system.digest
+  (:import (java.security MessageDigest)))
+
+(defn digest
+  ([input]
+   (digest input "SHA-256"))
+  ([input algorithm]
+   {:pre [(string? input)
+          (not (clojure.string/blank? input))
+          (#{"SHA-256" "SHA-1" "MD5"} algorithm)]}
+   (let [input-bytes (.getBytes input "UTF-8")
+         md          (doto
+                       (MessageDigest/getInstance algorithm)
+                       (.update input-bytes))
+         hash        (.digest md)
+         result      (apply str (map #(format "%02x" (bit-and % 0xff)) hash))]
+     result)))

--- a/test/org/zalando/stups/friboo/system/audit_logger/http_test.clj
+++ b/test/org/zalando/stups/friboo/system/audit_logger/http_test.clj
@@ -1,0 +1,31 @@
+(ns org.zalando.stups.friboo.system.audit-logger.http-test
+  (:require [midje.sweet :refer :all]
+            [clojure.test :refer [deftest]]
+            [clj-http.client :as http]
+            [org.zalando.stups.friboo.system.oauth2 :as oauth2]
+            [org.zalando.stups.friboo.system.digest :as digest]
+            [org.zalando.stups.friboo.system.audit-logger.http :as logger]))
+
+(deftest test-http-logger
+  (facts "HTTP logger"
+    (let [log-fn (logger/logger-factory {:api-url "http://foo.bar"} .tokens.)]
+      (fact "log function calls clj-http with provided url"
+        (log-fn {}) => nil
+        (provided
+          (digest/digest "{}") => "sha256"
+          (oauth2/access-token :http-audit-logger .tokens.) => .token.
+          (http/put "http://foo.bar/sha256" (contains {:body        "{}"
+                                                       :oauth-token .token.
+                                                       :as          :json})) => nil))
+      (fact "log-factory creates single-arity function"
+        (log-fn irrelevant irrelevant) => (throws Exception))
+      (fact "log logs to stdout if http call fails"
+        (log-fn {}) => nil
+        (provided
+          (digest/digest "{}") => "sha256"
+          (oauth2/access-token :http-audit-logger .tokens.) => .token.
+          ; this is what friboo.log/error ultimately expands to
+          (clojure.tools.logging/log* irrelevant :error irrelevant "Could not write audit event: [\"{}\"]") => nil :times 1
+          (http/put "http://foo.bar/sha256" (contains {:body        "{}"
+                                                       :oauth-token .token.
+                                                       :as          :json})) =throws=> (new Exception "400 Bad Request"))))))

--- a/test/org/zalando/stups/friboo/system/audit_logger/http_test.clj
+++ b/test/org/zalando/stups/friboo/system/audit_logger/http_test.clj
@@ -10,7 +10,7 @@
   (facts "HTTP logger"
     (let [log-fn (logger/logger-factory {:api-url "http://foo.bar"} .tokens.)]
       (fact "log function calls clj-http with provided url"
-        (log-fn {}) => nil
+        (deref (log-fn {})) => nil
         (provided
           (digest/digest "{}") => "sha256"
           (oauth2/access-token :http-audit-logger .tokens.) => .token.
@@ -20,7 +20,7 @@
       (fact "log-factory creates single-arity function"
         (log-fn irrelevant irrelevant) => (throws Exception))
       (fact "log logs to stdout if http call fails"
-        (log-fn {}) => nil
+        (deref (log-fn {})) => nil
         (provided
           (digest/digest "{}") => "sha256"
           (oauth2/access-token :http-audit-logger .tokens.) => .token.

--- a/test/org/zalando/stups/friboo/system/audit_logger/s3_test.clj
+++ b/test/org/zalando/stups/friboo/system/audit_logger/s3_test.clj
@@ -1,0 +1,38 @@
+(ns org.zalando.stups.friboo.system.audit-logger.s3-test
+  (:require [midje.sweet :refer :all]
+            [clojure.test :refer [deftest]]
+            [amazonica.aws.s3 :as s3]
+            [clj-time.format :as tf]
+            [org.zalando.stups.friboo.system.oauth2 :as oauth2]
+            [org.zalando.stups.friboo.system.digest :as digest]
+            [org.zalando.stups.friboo.system.audit-logger.s3 :as logger]))
+
+(deftest test-s3-logger
+  (facts "S3 logger"
+    (let [log-fn (logger/logger-factory {:s3-bucket .bucket-name.})]
+      (fact "log function calls s3/put-object with provided bucket"
+        (log-fn {}) => nil
+        (provided
+          (tf/unparse irrelevant irrelevant) => "/path/to/file/"
+          (digest/digest "{}") => "sha256"
+          (s3/put-object
+            :bucket-name .bucket-name.
+            :key "/path/to/file/sha256"
+            :metadata {:content-length 2
+                       :content-type   "application/json"}
+            :input-stream irrelevant) => nil))
+      (fact "log-factory creates single-arity function"
+        (log-fn irrelevant irrelevant) => (throws Exception))
+      (fact "log logs to stdout if s3 call fails"
+        (log-fn {}) => nil
+        (provided
+          (tf/unparse irrelevant irrelevant) => "/path/to/file/"
+          (digest/digest "{}") => "sha256"
+          ; this is what friboo.log/error ultimately expands to
+          (clojure.tools.logging/log* irrelevant :error irrelevant "Could not write audit event: [\"{}\"]") => nil :times 1
+          (s3/put-object
+            :bucket-name .bucket-name.
+            :key "/path/to/file/sha256"
+            :metadata {:content-length 2
+                       :content-type   "application/json"}
+            :input-stream irrelevant) =throws=> (new Exception "400 Bad Request"))))))

--- a/test/org/zalando/stups/friboo/system/audit_logger/s3_test.clj
+++ b/test/org/zalando/stups/friboo/system/audit_logger/s3_test.clj
@@ -3,7 +3,6 @@
             [clojure.test :refer [deftest]]
             [amazonica.aws.s3 :as s3]
             [clj-time.format :as tf]
-            [org.zalando.stups.friboo.system.oauth2 :as oauth2]
             [org.zalando.stups.friboo.system.digest :as digest]
             [org.zalando.stups.friboo.system.audit-logger.s3 :as logger]))
 
@@ -11,7 +10,7 @@
   (facts "S3 logger"
     (let [log-fn (logger/logger-factory {:s3-bucket .bucket-name.})]
       (fact "log function calls s3/put-object with provided bucket"
-        (log-fn {}) => nil
+        (deref (log-fn {})) => nil
         (provided
           (tf/unparse irrelevant irrelevant) => "/path/to/file/"
           (digest/digest "{}") => "sha256"
@@ -24,7 +23,7 @@
       (fact "log-factory creates single-arity function"
         (log-fn irrelevant irrelevant) => (throws Exception))
       (fact "log logs to stdout if s3 call fails"
-        (log-fn {}) => nil
+        (deref (log-fn {})) => nil
         (provided
           (tf/unparse irrelevant irrelevant) => "/path/to/file/"
           (digest/digest "{}") => "sha256"

--- a/test/org/zalando/stups/friboo/system/digest_test.clj
+++ b/test/org/zalando/stups/friboo/system/digest_test.clj
@@ -1,0 +1,27 @@
+(ns org.zalando.stups.friboo.system.digest-test
+  (:require [midje.sweet :refer :all]
+            [clojure.test :refer [deftest]]
+            [org.zalando.stups.friboo.system.digest :as d]))
+
+(def test-string "foobar")
+(def sha256 "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2")
+(def sha1 "8843d7f92416211de9ebb963ff4ce28125932878")
+(def md5 "3858f62230ac3c915f300c664312c63f")
+
+(deftest test-digest
+  (facts "digest"
+    (fact "creates sha-256 hash by default"
+      (d/digest test-string) => sha256)
+    (fact "uses provided algorithm"
+      (d/digest test-string "MD5") => md5
+      (d/digest test-string "SHA-1") => sha1
+      (d/digest test-string "SHA-256") => sha256)
+    (fact "throws when an unsupported algorithm is provided"
+      (d/digest test-string "SHA-2") => (throws AssertionError))
+    (fact "throws when input is nil or blank or not a string"
+      (d/digest nil) => (throws AssertionError)
+      (d/digest "") => (throws AssertionError)
+      (d/digest {}) => (throws AssertionError)
+      (d/digest []) => (throws AssertionError)
+      (d/digest true) => (throws AssertionError)
+      (d/digest false) => (throws AssertionError))))

--- a/test/org/zalando/stups/friboo/system/digest_test.clj
+++ b/test/org/zalando/stups/friboo/system/digest_test.clj
@@ -5,19 +5,11 @@
 
 (def test-string "foobar")
 (def sha256 "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2")
-(def sha1 "8843d7f92416211de9ebb963ff4ce28125932878")
-(def md5 "3858f62230ac3c915f300c664312c63f")
 
 (deftest test-digest
   (facts "digest"
-    (fact "creates sha-256 hash by default"
+    (fact "creates sha-256 hash"
       (d/digest test-string) => sha256)
-    (fact "uses provided algorithm"
-      (d/digest test-string "MD5") => md5
-      (d/digest test-string "SHA-1") => sha1
-      (d/digest test-string "SHA-256") => sha256)
-    (fact "throws when an unsupported algorithm is provided"
-      (d/digest test-string "SHA-2") => (throws AssertionError))
     (fact "throws when input is nil or blank or not a string"
       (d/digest nil) => (throws AssertionError)
       (d/digest "") => (throws AssertionError)


### PR DESCRIPTION
# Fixes #79

Introduces two new components, a `HTTP` and a `S3` audit logger, which provide a function that, when called, will write the provided clojure map to the destination.

I know we wanted to use timbre and provide a single audit log component, but this structure didn't make sense anymore when I realized we need access tokens for the `HTTP` component and it's thus dependent on the token-refreshing component. I dropped timbre afterwards because I didn't see the benefit anymore - we don't use the string serialization of it, we write our own appenders...

Could be discussed:
- put important part of `log` function in a `go` block so that it's async - the application doesn't care about the result anyways / can't/won't handle errors
- make http audit logger less dependent on oauth component, so that it can be used with unsecured APIs
- make http method to use in http audit logger configurable
