### PR TITLE
Avoid closing DB datasource more than once

### DIFF
--- a/src/org/zalando/stups/friboo/system/db.clj
+++ b/src/org/zalando/stups/friboo/system/db.clj
@@ -67,7 +67,7 @@
     (do
       (log/info "Stopping DB connection pool.")
       (.close (:datasource component))
-      (assoc component :pool nil))))
+      (assoc component :datasource nil))))
 
 (defmacro def-db-component
   "Defines a new database component."

--- a/test/org/zalando/stups/friboo/system/db_test.clj
+++ b/test/org/zalando/stups/friboo/system/db_test.clj
@@ -28,3 +28,13 @@
       (-> (f/parse (f/formatters :date-time) timestamp-string) .getMillis)
       ; fasterxml jackson's ISO8601Utils
       (-> (ISO8601Utils/parse timestamp-string (ParsePosition. 0)) .getTime))))
+
+(deftest test-db-component-lifecycle
+  (let [close-count (atom 0)
+        db-component {:datasource (reify java.io.Closeable
+                                    (close [this]
+                                      (swap! close-count inc)))}
+        stopped-db-component (stop-component db-component)]
+    (is (= 1 @close-count))
+    (stop-component stopped-db-component)
+    (is (= 1 @close-count))))


### PR DESCRIPTION
Second call to component stop would produce exception.
Not holding a reference to datasource would presumably help with GC.
