### PR TITLE
OAuth2 and security related improvements

### DIFF
--- a/src/org/zalando/stups/friboo/config.clj
+++ b/src/org/zalando/stups/friboo/config.clj
@@ -54,7 +54,7 @@
     (config namespace)
     (into {} (map (fn [[k v]] [(strip (name namespace) k) v])
                   (filter (fn [[k v]]
-                            (.startsWith (name k) (str (name namespace) "")))
+                            (.startsWith (name k) (str (name namespace) "-")))
                           config)))))
 
 (defn parse-namespaces [config namespaces]

--- a/src/org/zalando/stups/friboo/config.clj
+++ b/src/org/zalando/stups/friboo/config.clj
@@ -16,8 +16,7 @@
   (:require [environ.core :as environ]
             [org.zalando.stups.friboo.log :as log]
             [clojure.string :as str]
-            [amazonica.aws.kms :as kms]
-            [clojure.data.codec.base64 :as b64]))
+            [org.zalando.stups.friboo.config-decrypt :as decrypt]))
 
 (defn- nil-or-empty?
   "If x is a string, returns true if nil or empty. Else returns true if x is nil"
@@ -33,8 +32,6 @@
     (if (nil-or-empty? value)
       (throw (IllegalArgumentException. (str "Configuration " key " is required but is missing.")))
       value)))
-
-(def aws-kms-prefix "aws:kms:")
 
 (defn- is-sensitive-key [k]
   (let [kname (name k)]
@@ -63,62 +60,18 @@
       (log/debug "Destructured %s into %s." namespace (mask namespaced-config)))
     namespaced-configs))
 
-(defn- get-kms-ciphertext-blob [s]
-  "Convert config string to ByteBuffer"
-  (-> s
-      (clojure.string/replace-first aws-kms-prefix "")
-      .getBytes
-      b64/decode
-      java.nio.ByteBuffer/wrap))
+(defn remap-keys [input mapping]
+  (merge
+    (into {} (for [[new-key old-key] mapping
+                   :let [old-value (get input old-key)]
+                   :when old-value]
+               [new-key old-value]))
+    input))
 
-(defn decrypt-value-with-aws-kms [value aws-region-id]
-  "Use AWS Key Management Service to decrypt the given string (must be encoded as Base64)"
-  (->> value
-       get-kms-ciphertext-blob
-       (#(kms/decrypt {:endpoint aws-region-id} :ciphertext-blob %))
-       :plaintext
-       .array
-       (map char)
-       (apply str)))
-
-(defn- decrypt-value [key value aws-region-id]
-  "Decrypt a single value, returns original value if it's not encrypted"
-  (if (and (string? value) (.startsWith value aws-kms-prefix))
-    (do
-      (log/info "Decrypting configuration %s." key)
-      (decrypt-value-with-aws-kms value aws-region-id))
-    value))
-
-(defn- to-real-boolean
-  "Maps a boolean string to boolean or returns the string."
-  [value]
-  (if (string? value)
-    (case value
-      "true" true
-      "false" false
-      value)
-    value))
-
-(defn- to-real-number
-  "Maps a number string to long or returns the string."
-  [value]
-  (if (and (string? value) (not (nil? (re-matches #"^[0-9]+$" value))))
-    (Long/parseLong value)
-    value))
-
-(defn decrypt [config]
-  "Decrypt all values in a config map"
-  (into {} (for [[k v] config]
-             [k (-> (decrypt-value k v (:aws-region-id config))
-                    (to-real-boolean)
-                    (to-real-number))])))
-
-(defn load-configuration
+(defn load-config
   "Loads the configuration from different sources and transforms it.
 
-  Takes default configurations, merges them in the order they are provided:
-  [{:http-port 8080 :tokeninfo-url \"bar\"}, {:tokeninfo-url \"foo\"}] -> {:http-port 8080 :tokeninfo-url \"foo\"}
-  Then merges the environment variables into it:
+  Merges default config with environment variables:
   {:http-port 8080 :tokeninfo-url \"foo\"}, {:http-port 9090} -> {:http-port 9090 :tokeninfo-url \"foo\"}
   Then optionally renames some keys, but only if the new key does not exist:
   {:http-tokeninfo-url :tokeninfo-url}, {:http-port 9090 :tokeninfo-url \"foo\"}
@@ -127,21 +80,20 @@
   [:http], {:http-port 9090 :tokeninfo-url \"foo\" :http-tokeninfo-url \"foo\"}
     -> {:http-port 9090 :http-tokeninfo-url \"foo\"}
   Then extracts namespaces:
-  {:http-port 9090 :http-tokeninfo-url \"foo\"} -> {:http {:port 9090 :tokeninfo-url \"foo\""
+  {:http-port 9090 :http-tokeninfo-url \"foo\"} -> {:http {:port 9090 :tokeninfo-url \"foo\"}}"
 
-  ;; TODO in version 2 use only one default configuration, let the caller call merge
-  ([namespaces default-configurations]
-   (load-configuration namespaces
-                       ;; TODO in version 2 don't use default demapping, move to a separate Zalando-specific namespace
-                       {:http-tokeninfo-url     :tokeninfo-url
-                        :oauth2-credentials-dir :credentials-dir}
-                       default-configurations))
+  [default-config namespaces & [{:keys [mapping]}]]
+  (-> (merge default-config environ/env)
+      (remap-keys mapping)
+      (parse-namespaces (conj namespaces :system))))
 
-  ([namespaces globals-mapping default-configurations]
-   (let [env-with-defaults                (apply merge (conj default-configurations environ/env))
-         remappings                       (into {} (for [[new-key old-key] globals-mapping
-                                                         :let [old-value (get env-with-defaults old-key)]
-                                                         :when old-value]
-                                                     [new-key old-value]))
-         env-with-remappings-and-defaults (merge remappings env-with-defaults)]
-     (parse-namespaces (decrypt env-with-remappings-and-defaults) (conj namespaces :system)))))
+(defn load-configuration
+  "Loads configuration with Zalando-specific tweaks (remapping and decryption) in place."
+  ;; TODO move this function into the Zalando-specific library
+  [namespaces default-configurations]
+  (decrypt/decrypt-config
+    (load-config
+      (apply merge default-configurations)
+      namespaces
+      {:mapping {:http-tokeninfo-url     :tokeninfo-url
+                 :oauth2-credentials-dir :credentials-dir}})))

--- a/src/org/zalando/stups/friboo/config_decrypt.clj
+++ b/src/org/zalando/stups/friboo/config_decrypt.clj
@@ -1,0 +1,63 @@
+(ns org.zalando.stups.friboo.config-decrypt
+  (:require [org.zalando.stups.friboo.log :as log]
+            [amazonica.aws.kms :as kms]
+            [clojure.data.codec.base64 :as b64])
+  (:import (java.nio ByteBuffer)))
+
+(def aws-kms-prefix "aws:kms:")
+
+(defn- get-kms-ciphertext-blob [s]
+  "Convert config string to ByteBuffer"
+  (-> s
+      (clojure.string/replace-first aws-kms-prefix "")
+      .getBytes
+      b64/decode
+      ByteBuffer/wrap))
+
+(defn decrypt-value-with-aws-kms [value aws-region-id]
+  "Use AWS Key Management Service to decrypt the given string (must be encoded as Base64)"
+  (->> value
+       get-kms-ciphertext-blob
+       (#(kms/decrypt {:endpoint aws-region-id} {:ciphertext-blob %}))
+       :plaintext
+       .array
+       (map char)
+       (apply str)))
+
+(defn- decrypt-value [key value aws-region-id]
+  "Decrypt a single value, returns original value if it's not encrypted"
+  (if (and (string? value) (.startsWith value aws-kms-prefix))
+    (do
+      (log/info "Decrypting configuration %s." key)
+      (decrypt-value-with-aws-kms value aws-region-id))
+    value))
+
+(defn- to-real-boolean
+  "Maps a boolean string to boolean or returns the string."
+  [value]
+  (if (string? value)
+    (case value
+      "true" true
+      "false" false
+      value)
+    value))
+
+(defn- to-real-number
+  "Maps a number string to long or returns the string."
+  [value]
+  (if (and (string? value) (not (nil? (re-matches #"^[0-9]+$" value))))
+    (Long/parseLong value)
+    value))
+
+(defn decrypt [config]
+  "Decrypt all values in a config map"
+  (into {} (for [[k v] config]
+             [k (-> (decrypt-value k v (:aws-region-id config))
+                    (to-real-boolean)
+                    (to-real-number))])))
+
+(defn decrypt-config
+  "Decrypts 2-level config map."
+  [config-map]
+  (into {} (for [[config-ns subconfig] config-map]
+             [config-ns (decrypt subconfig)])))

--- a/src/org/zalando/stups/friboo/security.clj
+++ b/src/org/zalando/stups/friboo/security.clj
@@ -38,7 +38,7 @@
   (api/error 403 "Forbidden"))
 
 (defn allow-all
-  "Returns a swagger1st security hander that allows everything."
+  "Returns a swagger1st security handler that allows everything."
   []
   (fn [request definition requirements]
     request))

--- a/src/org/zalando/stups/friboo/security.clj
+++ b/src/org/zalando/stups/friboo/security.clj
@@ -1,0 +1,124 @@
+; Copyright © 2016 Zalando SE
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;    http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+(ns org.zalando.stups.friboo.security
+  (:require [org.zalando.stups.friboo.log :as log]
+            [clj-http.client :as client]
+            [clojure.core.memoize :as memo]
+            [clojure.core.cache :as cache]
+            [io.sarnowski.swagger1st.util.api :as api]
+            [com.netflix.hystrix.core :refer [defcommand]]))
+
+(defn- unauthorized
+  "Send forbidden response."
+  [reason]
+  (log/warn "ACCESS DENIED (unauthorized) because %s." reason)
+  (api/error 401 "Unauthorized"))
+
+(defn- unauthorized-without-logging
+  "Send forbidden response."
+  [reason]
+  (api/error 401 "Unauthorized"))
+
+(defn- forbidden
+  "Send forbidden response."
+  [reason]
+  (log/warn "ACCESS DENIED (forbidden) because %s." reason)
+  (api/error 403 "Forbidden"))
+
+(defn allow-all
+  "Returns a swagger1st security hander that allows everything."
+  []
+  (fn [request definition requirements]
+    request))
+
+(defn- extract-access-token
+  "Extracts the bearer token from the Authorization header."
+  [request]
+  (if-let [authorization (get-in request [:headers "authorization"])]
+    (when (.startsWith authorization "Bearer ")
+      (.substring authorization (count "Bearer ")))))
+
+(defn check-consented-scopes
+  "Checks if every scope is mentioned in the 'scope' attribute of the token info."
+  [tokeninfo scopes]
+  (let [consented-scopes (set (get tokeninfo "scope"))]
+    (every? #(contains? consented-scopes %) scopes)))
+
+(defn check-corresponding-attributes
+  "Checks if every scope has a truethy attribute in the token info of the same name."
+  [tokeninfo scopes]
+  (let [scope-as-attribute-true? (fn [scope]
+                                   (get tokeninfo scope))]
+    (every? scope-as-attribute-true? scopes)))
+
+(defcommand
+  fetch-tokeninfo
+  [tokeninfo-url access-token]
+  (let [response (client/get tokeninfo-url
+                             {:query-params     {:access_token access-token}
+                              :throw-exceptions false
+                              :as               :json-string-keys})]
+    (if (client/server-error? response)
+      (throw (IllegalStateException. (str "tokeninfo endpoint returned status code: " (:status response))))
+      response)))
+
+(defn resolve-access-token-real
+  "Checks with a tokeninfo endpoint for the token's validity and returns the session information if valid.
+  Otherwise returns nil."
+  [tokeninfo-url access-token]
+  (let [response (fetch-tokeninfo tokeninfo-url access-token)]
+    (when (client/success? response)
+      (:body response))))
+
+(def resolve-access-token
+  "Cache token info for 2 minutes"
+  (memo/fifo resolve-access-token-real (cache/ttl-cache-factory {} :ttl 120000) :fifo/threshold 100))
+
+(defn oauth2
+  "Returns a swagger1st security handler that checks OAuth 2.0 tokens.
+   * config-fn takes one parameter for getting configuration values. Configuration values:
+   ** :tokeninfo-url
+   * check-scopes-fn takes tokeninfo and scopes data and returns if token is valid"
+  [get-config-fn check-scopes-fn & {:keys [resolver-fn]
+                                    :or   {resolver-fn resolve-access-token}}]
+  (fn [request definition requirements]
+    ; get access token from request
+    (if-let [access-token (extract-access-token request)]
+      (let [tokeninfo-url (get-config-fn :tokeninfo-url)]
+        (if tokeninfo-url
+          ; check access token
+          (if-let [tokeninfo (resolver-fn tokeninfo-url access-token)]
+            ; check scopes
+            (if (check-scopes-fn tokeninfo requirements)
+              (assoc request :tokeninfo tokeninfo)
+              (forbidden "scopes not granted"))
+            (unauthorized "invalid access token"))
+          (api/error 503 "token info misconfigured")))
+      (unauthorized-without-logging "no access token given"))))
+
+(defn make-oauth2-security-handler [tokeninfo-url]
+  (if tokeninfo-url
+    (do
+      (log/info "Checking access tokens against %s." tokeninfo-url)
+      (oauth2 {:tokeninfo-url tokeninfo-url}
+              check-corresponding-attributes
+              :resolver-fn resolve-access-token))
+    (do
+      (log/warn "No token info URL configured; NOT ENFORCING SECURITY!")
+      (allow-all))))
+
+(def allow-all-handlers {"oauth2" (allow-all)
+                         "basic"  (allow-all)
+                         "apiKey" (allow-all)})

--- a/src/org/zalando/stups/friboo/system/oauth2.clj
+++ b/src/org/zalando/stups/friboo/system/oauth2.clj
@@ -18,7 +18,7 @@
             [cheshire.core :as json]
             [clojure.java.io :as io]
             [clojure.string :as str])
-  (:import (org.zalando.stups.tokens Tokens ClientCredentialsProvider ClientCredentials UserCredentialsProvider UserCredentials CredentialsUnavailableException AccessTokensBuilder AccessTokens)
+  (:import (org.zalando.stups.tokens Tokens ClientCredentialsProvider ClientCredentials UserCredentialsProvider UserCredentials CredentialsUnavailableException AccessTokensBuilder AccessTokens AccessTokenUnavailableException)
            (java.net URI)))
 
 (defn make-client-credentials-provider [file]
@@ -101,7 +101,9 @@
 (defn access-token
   "Returns the valid access token of the given ID."
   [token-id {:keys [token-storage static-tokens]}]
-  (if-let [static-token (get static-tokens token-id)]
-    static-token
-    (when token-storage
-      (.get token-storage token-id))))
+  (or
+    (if-let [static-token (get static-tokens token-id)]
+      static-token
+      (when token-storage
+        (.get token-storage token-id)))
+    (throw (AccessTokenUnavailableException. "Token was not registered."))))

--- a/src/org/zalando/stups/friboo/system/oauth2.clj
+++ b/src/org/zalando/stups/friboo/system/oauth2.clj
@@ -1,3 +1,17 @@
+; Copyright © 2016 Zalando SE
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;    http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
 (ns org.zalando.stups.friboo.system.oauth2
   (:require [org.zalando.stups.friboo.config :refer [require-config]]
             [com.stuartsierra.component :as component]
@@ -6,22 +20,43 @@
             [clj-http.client :as client]
             [clojure.core.cache :as cache]
             [clojure.core.memoize :as memo]
-            [com.netflix.hystrix.core :refer [defcommand]]
-            [org.zalando.stups.friboo.log :as log])
-  (:import (org.zalando.stups.tokens Tokens)
-           (java.net URI)
-           (java.io IOException)))
+            [org.zalando.stups.friboo.log :as log]
+            [cheshire.core :as json]
+            [clojure.java.io :as io])
+  (:import (org.zalando.stups.tokens Tokens ClientCredentialsProvider ClientCredentials UserCredentialsProvider UserCredentials CredentialsUnavailableException)
+           (java.net URI)))
 
+(defn make-client-credentials-provider [file]
+  (reify ClientCredentialsProvider
+    (get [_]
+      (let [{:strs [client_id client_secret]} (json/parse-string (slurp file))]
+        (reify ClientCredentials
+          (getId [_] client_id)
+          (getSecret [_] client_secret))))))
+
+(defn make-user-credentials-provider [file]
+  (reify UserCredentialsProvider
+    (get [_]
+      (let [{:strs [application_username application_password]} (json/parse-string (slurp file))]
+        (reify UserCredentials
+          (getUsername [_] application_username)
+          (getPassword [_] application_password))))))
 
 ; configuration has to be given, contains links to IAM solution and timings
 ; tokens has to be given, contains map of tokenids to list of required scopes
 ; token-storage will be an atom containing the current access token
-(defrecord OAUth2TokenRefresher [configuration tokens token-storage]
+(defrecord OAuth2TokenRefresher [configuration tokens token-storage]
   component/Lifecycle
 
   (start [this]
     (let [access-token-url (require-config configuration :access-token-url)
-          token-builder (Tokens/createAccessTokensWithUri (URI. access-token-url))]
+          credentials-dir  (require-config configuration :credentials-dir)
+          ;; Provide custom implementations to prevent the library from using System.getenv("CREDENTIALS_DIR")
+          token-builder    (-> (Tokens/createAccessTokensWithUri (URI. access-token-url))
+                               (.usingClientCredentialsProvider
+                                 (make-client-credentials-provider (io/file credentials-dir "client.json")))
+                               (.usingUserCredentialsProvider
+                                 (make-user-credentials-provider (io/file credentials-dir "user.json"))))]
 
       ; register all scopes
       (doseq [[token-id scopes] tokens]
@@ -38,94 +73,6 @@
 
 (defn access-token
   "Returns the valid access token of the given ID."
-  [token-id ^OAUth2TokenRefresher refresher]
+  [token-id ^OAuth2TokenRefresher refresher]
   (let [token-storage (:token-storage refresher)]
     (.get token-storage token-id)))
-
-
-(defn- unauthorized
-  "Send forbidden response."
-  [reason]
-  (log/warn "ACCESS DENIED (unauthorized) because %s." reason)
-  (api/error 401 "Unauthorized"))
-
-(defn- unauthorized-without-logging
-  "Send forbidden response."
-  [reason]
-  (api/error 401 "Unauthorized"))
-
-(defn- forbidden
-  "Send forbidden response."
-  [reason]
-  (log/warn "ACCESS DENIED (forbidden) because %s." reason)
-  (api/error 403 "Forbidden"))
-
-(defn allow-all
-  "Allows everything."
-  []
-  (fn [request definition requirements]
-    request))
-
-(defn- extract-access-token
-  "Extracts the bearer token from the Authorization header."
-  [request]
-  (if-let [authorization (get-in request [:headers "authorization"])]
-    (when (.startsWith authorization "Bearer ")
-      (.substring authorization (count "Bearer ")))))
-
-(defn check-consented-scopes
-  "Checks if every scope is mentioned in the 'scope' attribute of the token info."
-  [tokeninfo scopes]
-  (let [consented-scopes (set (get tokeninfo "scope"))]
-    (every? consented-scopes scopes)))
-
-(defn check-corresponding-attributes
-  "Checks if every scope has a truethy attribute in the token info of the same name."
-  [tokeninfo scopes]
-  (let [scope-as-attribute-true? (fn [scope]
-                                   (get tokeninfo scope))]
-    (every? scope-as-attribute-true? scopes)))
-
-(defcommand
-  fetch-tokeninfo
-  [tokeninfo-url access-token]
-  (let [response (client/get tokeninfo-url
-                             {:query-params     {:access_token access-token}
-                              :throw-exceptions false
-                              :as               :json-string-keys})]
-    (if (client/server-error? response)
-      (throw (IllegalStateException. (str "tokeninfo endpoint returned status code: " (:status response))))
-      response)))
-
-(defn resolve-access-token-real
-  "Checks with a tokeninfo endpoint for the token's validity and returns the session information if valid."
-  [tokeninfo-url access-token]
-  (let [response (fetch-tokeninfo tokeninfo-url access-token)
-        body (:body response)]
-    (when (client/success? response) body)))
-
-(def resolve-access-token
-  "Cache token info for 2 minutes"
-  (memo/fifo resolve-access-token-real (cache/ttl-cache-factory {} :ttl 120000) :fifo/threshold 100))
-
-(defn oauth-2.0
-  "Checks OAuth 2.0 tokens.
-   * config-fn takes one parameter for getting configuration values. Configuration values:
-   ** :tokeninfo-url
-   * check-scopes-fn takes tokeninfo and scopes data and returns if token is valid"
-  [get-config-fn check-scopes-fn & {:keys [resolver-fn]
-                                    :or   {resolver-fn resolve-access-token}}]
-  (fn [request definition requirements]
-    ; get access token from request
-    (if-let [access-token (extract-access-token request)]
-      (let [tokeninfo-url (get-config-fn :tokeninfo-url)]
-        (if tokeninfo-url
-          ; check access token
-          (if-let [tokeninfo (resolver-fn tokeninfo-url access-token)]
-            ; check scopes
-            (if (check-scopes-fn tokeninfo requirements)
-              (assoc request :tokeninfo tokeninfo)
-              (forbidden "scopes not granted"))
-            (unauthorized "invalid access token"))
-          (api/error 503 "token info misconfigured")))
-      (unauthorized-without-logging "no access token given"))))

--- a/test/org/zalando/stups/friboo/config_test.clj
+++ b/test/org/zalando/stups/friboo/config_test.clj
@@ -1,8 +1,10 @@
 (ns org.zalando.stups.friboo.config-test
   (:require
     [clojure.test :refer :all]
+    [midje.sweet :refer :all]
     [org.zalando.stups.friboo.config :refer :all]
-    [amazonica.aws.kms :as kms])
+    [amazonica.aws.kms :as kms]
+    [environ.core :as environ])
   (:import [java.nio ByteBuffer]))
 
 (deftest test-config-parse
@@ -20,3 +22,50 @@
                                                         .getBytes
                                                         ByteBuffer/wrap)})]
     (is (= "secret" (decrypt-value-with-aws-kms "abc" "region-1")))))
+
+(deftest wrap-midje-facts
+
+  (facts "about load-configuration"
+
+    (fact "If TOKENINFO_URL is not set, no remapping is done"
+      (with-redefs [environ/env {}]
+        (load-configuration [:tokeninfo :http] {:http-tokeninfo-url :tokeninfo-url} []))
+      => {:system    {}
+          :tokeninfo {}
+          :http      {}})
+
+    (fact "TOKENINFO_URL is implicitly duplicated as HTTP_TOKENINFO_URL"
+      (with-redefs [environ/env {:tokeninfo-url ..tokeninfo-url..}]
+        (load-configuration [:tokeninfo :http] {:http-tokeninfo-url :tokeninfo-url} []))
+      => {:system    {}
+          :tokeninfo {:url ..tokeninfo-url..}
+          :http      {:tokeninfo-url ..tokeninfo-url..}})
+
+    (fact "User's HTTP_TOKENINFO_URL takes precedence over the duplication"
+      (with-redefs [environ/env {:tokeninfo-url      ..tokeninfo-url..
+                                 :http-tokeninfo-url ..http-tokeninfo-url..}]
+        (load-configuration [:tokeninfo :http] {:http-tokeninfo-url :tokeninfo-url} []))
+      => {:system    {}
+          :tokeninfo {:url ..tokeninfo-url..}
+          :http      {:tokeninfo-url ..http-tokeninfo-url..}})
+
+    (fact "Remapping is done even before namespacing"
+      (with-redefs [environ/env {:tokeninfo-url ..tokeninfo-url..}]
+        (load-configuration [:http] {:http-tokeninfo-url :tokeninfo-url} []))
+      => {:system    {}
+          :http      {:tokeninfo-url ..tokeninfo-url..}})
+
+    (fact "By default, TOKENINFO_URL is remapped to HTTP_TOKENINFO_URL"
+      (with-redefs [environ/env {:tokeninfo-url ..tokeninfo-url..}]
+        (load-configuration [:http] []))
+      => {:system    {}
+          :http      {:tokeninfo-url ..tokeninfo-url..}})
+
+    (fact "By default, TOKENINFO_URL is remapped to HTTP_TOKENINFO_URL, and HTTP_TOKENINFO_URL takes precedence too."
+      (with-redefs [environ/env {:tokeninfo-url ..tokeninfo-url..
+                                 :http-tokeninfo-url ..http-tokeninfo-url..}]
+        (load-configuration [:http] []))
+      => {:system    {}
+          :http      {:tokeninfo-url ..http-tokeninfo-url..}}))
+
+  )

--- a/test/org/zalando/stups/friboo/config_test.clj
+++ b/test/org/zalando/stups/friboo/config_test.clj
@@ -8,7 +8,8 @@
   (:import [java.nio ByteBuffer]))
 
 (deftest test-config-parse
-  (is (= {:connect-timeout "123"} (:ldap (parse-namespaces {:ldap-connect-timeout "123"} [:ldap])))))
+  (is (= {:connect-timeout "123"} (:ldap (parse-namespaces {:ldap-connect-timeout "123"} [:ldap]))))
+  (is (= {:connect-timeout "123"} (:ldap (parse-namespaces {:ldap-connect-timeout "123" :ldapfoo "bar"} [:ldap])))))
 
 (deftest test-mask
   (is (= {:a "b" :password "MASKED" :private-stuff "MASKED" :my-secret-key "MASKED"}

--- a/test/org/zalando/stups/friboo/security_test.clj
+++ b/test/org/zalando/stups/friboo/security_test.clj
@@ -1,0 +1,53 @@
+(ns org.zalando.stups.friboo.security-test
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [org.zalando.stups.friboo.security :refer :all]
+            [clj-http.client :as client]))
+
+(deftest wrap-midje-facts
+
+  (facts "about check-corresponding-attributes"
+    (check-corresponding-attributes {"application.write" true} ["application.write"]) => truthy
+    (check-corresponding-attributes {"application.write" true} ["application.write_all"]) => falsey
+    (check-corresponding-attributes {"application.write" nil} ["application.write"]) => falsey)
+
+  (facts "about checking oauth2 tokens"
+
+    (fact "if no tokenninfo-url specified, do not check tokens"
+      ((make-oauth2-security-handler nil) ..request.. anything anything) => ..request..)
+
+    (fact "when tokeninfo returns 200, adds its response to the request"
+      (with-redefs [resolve-access-token resolve-access-token-real]
+        ((make-oauth2-security-handler ..tokeninfo-url..) {:headers {"authorization" "Bearer foo"}}
+          nil
+          ["application.write"]))
+      => {:headers {"authorization" "Bearer foo"} :tokeninfo {"application.write" true}}
+      (provided
+        (client/get ..tokeninfo-url.. anything)
+        => {:status 200 :body {"application.write" true}}))
+
+    (fact "when there are insufficient scopes, return 403"
+      (with-redefs [resolve-access-token resolve-access-token-real]
+        ((make-oauth2-security-handler ..tokeninfo-url..) {:headers {"authorization" "Bearer foo"}}
+          nil
+          ["application.write"]))
+      => (contains {:status 403})
+      (provided
+        (client/get ..tokeninfo-url.. anything)
+        => {:status 200 :body {}}))
+
+    (fact "when tokeninfo fails, return 401"
+      (with-redefs [resolve-access-token resolve-access-token-real]
+        ((make-oauth2-security-handler ..tokeninfo-url..) {:headers {"authorization" "Bearer foo"}}
+          nil
+          []))
+      => (contains {:status 401})
+      (provided
+        (client/get ..tokeninfo-url.. anything)
+        => {:status 400 :body {}}))
+
+    (fact "when there is no token in the request, return 401"
+      ((make-oauth2-security-handler ..tokeninfo-url..) {:headers {}} nil [])
+      => (contains {:status 401})))
+
+  )

--- a/test/org/zalando/stups/friboo/system/oauth2_test.clj
+++ b/test/org/zalando/stups/friboo/system/oauth2_test.clj
@@ -3,7 +3,7 @@
             [midje.sweet :refer :all]
             [org.zalando.stups.friboo.system.oauth2 :refer :all]
             [com.stuartsierra.component :as component])
-  (:import (org.zalando.stups.tokens AccessTokens)))
+  (:import (org.zalando.stups.tokens AccessTokens AccessTokenUnavailableException)))
 
 (defn create-access-tokens-mock [token-map]
   (reify AccessTokens
@@ -30,6 +30,8 @@
           (access-token :bar refresher) => "real-bar")
         (fact "static token takes precedence"
           (access-token :baz refresher) => "fake-baz")
+        (fact "if the token was not registered, throws an exception"
+          (access-token :nonono refresher) => (throws AccessTokenUnavailableException))
         (fact "stopping"
           (component/stop refresher) => (contains {:token-storage nil})))))
 

--- a/test/org/zalando/stups/friboo/system/oauth2_test.clj
+++ b/test/org/zalando/stups/friboo/system/oauth2_test.clj
@@ -1,0 +1,36 @@
+(ns org.zalando.stups.friboo.system.oauth2-test
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [org.zalando.stups.friboo.system.oauth2 :refer :all]
+            [com.stuartsierra.component :as component])
+  (:import (org.zalando.stups.tokens AccessTokens)))
+
+(defn create-access-tokens-mock [token-map]
+  (reify AccessTokens
+    (get [_ token-id]
+      (get token-map token-id))
+    (stop [_])))
+
+(deftest wrap-midje-facts
+
+  (facts "about parse-static-tokens"
+    (parse-static-tokens "token1=foo,token2,token3=bar") => {:token1 "foo" :token3 "bar"})
+
+  (facts "about OAuth2TokenRefresher"
+    (with-redefs [AccessTokensBuilder-start (fn [_]
+                                              (create-access-tokens-mock {:bar "real-bar" :baz "real-baz"}))]
+      (let [refresher (component/start (map->OAuth2TokenRefresher
+                                         {:configuration {:access-token-url "access-token-url"
+                                                          :credentials-dir  "credentials-dir"
+                                                          :access-tokens    "foo=fake-foo,baz=fake-baz"}
+                                          :tokens        {:bar ["a"] :baz ["b"]}}))]
+        (fact "can retrieve static token"
+          (access-token :foo refresher) => "fake-foo")
+        (fact "can retrieve normal token"
+          (access-token :bar refresher) => "real-bar")
+        (fact "static token takes precedence"
+          (access-token :baz refresher) => "fake-baz")
+        (fact "stopping"
+          (component/stop refresher) => (contains {:token-storage nil})))))
+
+  )


### PR DESCRIPTION
- Fix #86 (allow static tokens for testing via `OAUTH2_ACCESS_TOKENS`, don't require `OAUTH2_ACCESS_TOKEN_URL`).
- Fix #89 (To qualify as namespace, require env var prefix to end with `_` when loading configuration) .
- Don't let Tokens library use `CREDENTIALS_DIR` env var directly, to support reloaded workflow.
- Separate incoming token checking functions and service token refreshing component into different namespaces.
- Improve configuration loading to support arbitrary mappings, not only `TOKENINFO_URL -> HTTP_TOKENINFO_URL` and `CREDENTIALS_DIR -> OAUTH2_CREDENTIALS_DIR`
