### PR TITLE
Bump swagger1st dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   :java-source-paths ["java"]
 
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.zalando/swagger1st "0.22.0" :exclusions [org.apache.httpcomponents/httpcore]]
+                 [org.zalando/swagger1st "0.22.1" :exclusions [org.apache.httpcomponents/httpcore]]
                  [org.zalando.stups/txdemarcator "0.7.0"]
                  [com.stuartsierra/component "0.3.1"]
                  [digest "1.4.5"]


### PR DESCRIPTION
The latest version of swagger1st fixes a [bug](https://github.com/zalando/swagger1st/issues/56) related to array parameters.